### PR TITLE
Updated to new XML API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,16 @@ InfusionSoft node.js SDK.
 
 ### Installation ###
 ```bash
-npm install infusionsoft 
+npm install infusionsoft
 ```
+
+### Usage ###
+Note that this now uses the newer XML-RPC location, but I have not added in support for refreshing OAuth tokens yet. Right now, you need to provide a valid access token to the methods for them to work and if the token has expired, you'll get an error.
 
 ### Usage ###
 ```javascript
 var iSDK = require('infusionsoft');
-var client = new iSDK('app_name', 'api_key');
+var client = new iSDK('access_token');
 ```
 
 ### Implemented methods ###

--- a/index.js
+++ b/index.js
@@ -1,13 +1,15 @@
 var xmlrpc = require('xmlrpc');
 var types = require('./lib/types');
 
-var iSDK = module.exports = function (appname, apikey, handler) {
-
-	this.appName = appname;
-	this.apiKey = apikey;
+var iSDK = module.exports = function (access_token, handler) {
+	this.accessToken = access_token;
 	this.responseHandler = handler || function () {};
-	this.client = xmlrpc.createSecureClient('https://' + this.appName + '.infusionsoft.com/api/xmlrpc');
-
+	this.client = xmlrpc.createSecureClient({
+		'host': 'api.infusionsoft.com',
+		'path': '/crm/xmlrpc/v1?access_token=' + access_token,
+		'port': null
+	});
+	this.apiKey = 'privateKey';
 };
 
 iSDK.prototype.methodCaller = function (service, data, callback) {


### PR DESCRIPTION
I've got things working with the new API locations using Oauth-based access tokens, since the older mechanism is deprecated for new apps.

I don't have support for refreshing new access tokens yet, but if you already have a valid, non-expired access token you can pass that in and it will get used. So to be clear, you no longer need the 'appName' which was the name of your installation/subdomain nor the API key, but you do need to have already generated the proper access token.

There's likely work that needs to be done before this can be merged all the way back in because we'll almost certainly need that token refresh ability. My usage of it doesn't require it though so perhaps someone else could jump in on that (I am generating the access tokens outside of Node and using them later).
